### PR TITLE
Add Sentry error handler to get more context about the failing requests

### DIFF
--- a/app-factory.js
+++ b/app-factory.js
@@ -75,6 +75,7 @@ module.exports.injectMiddlewaresAndListen = async ({
 
   if (isSentryEnabled) {
     app.use(sentry.Handlers.requestHandler());
+    app.use(sentry.Handlers.errorHandler());
   }
 
   if (isLogRequestEnabled) {


### PR DESCRIPTION
Na tentativa de enriquecer os registros de erros do Sentry, acrescentei o middleware que captura os erros emitidos.