### PR TITLE
[ADM-619] Add HSTS header

### DIFF
--- a/app-factory.js
+++ b/app-factory.js
@@ -116,6 +116,10 @@ module.exports.injectMiddlewaresAndListen = async ({
   app.use(bodyParser.json({ limit: '50mb' }));
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(restify.plugins.multipartBodyParser());
+  app.use((req, res, next) => {
+    res.header('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload')
+    return next();
+  })
   prometheusMiddleware.injectMetricsRoute(app);
 
   await injectSwaggerToApp({ app, appRoot, swaggerFile });


### PR DESCRIPTION
Esse PR adiciona o header Strict-Transport-Security.
Em poucas palavras, esse header obriga que as requisições sejam feitas em https.

Para mais informações, [leia esta explicação sobre o HSTS](https://gupy-io.atlassian.net/wiki/spaces/PROD/pages/1730773262/Utiliza+o+do+HSTS+nas+APIs).


Uma request em staging com o novo header:

![image](https://user-images.githubusercontent.com/34371620/111322929-316e1f80-8648-11eb-96ef-cf3ad5318921.png)

Como é um alteração que força https em todas request geitas pro domínio da gupy à partir do browser, passei pelos fluxos críticos da plataforma pra garantir que estava tudo funcionando.